### PR TITLE
Feat/guestbook

### DIFF
--- a/src/api/calendar.ts
+++ b/src/api/calendar.ts
@@ -1,5 +1,5 @@
 import { API_BASE_URL, API_ENDPOINTS, API_METHODS } from "@/constants/api";
-import { request } from ".";
+import { request, requestFormData } from ".";
 import {
   CalendarCardItem,
   CalendarItem,
@@ -75,23 +75,17 @@ export const updateCalendarCard = async (
 
     formData.append("data", JSON.stringify(jsonData));
 
-    return request<CalendarCardResponse>(url, {
+    // FormData를 사용할 때는 Content-Type 헤더를 제거 (브라우저가 자동으로 설정)
+    return requestFormData<CalendarCardResponse>(url, {
       method: API_METHODS.PUT,
       accessToken,
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
       body: formData,
     });
   } else {
-    // 파일이 없는 경우는 일반 JSON으로 전송
+    // 파일이 없는 경우는 기본 헤더 사용 (request 함수에서 자동으로 설정)
     return request<CalendarCardResponse>(url, {
       method: API_METHODS.PUT,
       accessToken,
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        "Content-Type": "application/json",
-      },
       body: JSON.stringify(data),
     });
   }

--- a/src/api/guestbook.ts
+++ b/src/api/guestbook.ts
@@ -32,6 +32,7 @@ export const createGuestbook = async (
     headers: {
       ...defaultHeaders,
     },
+    accessToken,
     body: JSON.stringify(data),
   });
 };

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -12,6 +12,8 @@ async function request<T>(
     headers.set("Authorization", `Bearer ${accessToken}`);
   }
 
+  headers.set("Content-Type", "application/json");
+
   const response = await fetch(url, { ...options, headers });
 
   if (!response.ok) {
@@ -22,4 +24,24 @@ async function request<T>(
   return data;
 }
 
-export { request };
+async function requestFormData<T>(
+  url: string,
+  { accessToken, ...options }: RequestOptions = {}
+): Promise<T> {
+  const headers = new Headers(options.headers || {});
+
+  if (accessToken) {
+    headers.set("Authorization", `Bearer ${accessToken}`);
+  }
+
+  const response = await fetch(url, { ...options, headers });
+
+  if (!response.ok) {
+    throw new Error(`HTTP Error: ${response.status}`);
+  }
+
+  const data = (await response.json()) as T;
+  return data;
+}
+
+export { request, requestFormData };

--- a/src/components/calendars/index.tsx
+++ b/src/components/calendars/index.tsx
@@ -159,7 +159,9 @@ const Calendar = ({ isBlurred, userId }: CalendarProps) => {
   // };
 
   const handleCalendarClick = (day: number) => {
-    router.push(`/calendars/card/${userId}/${day}`);
+    userId
+      ? router.push(`/calendars/card/user/${userId}/${day}`)
+      : router.push(`/calendars/card/${day}`);
   };
 
   return (

--- a/src/components/calendars/index.tsx
+++ b/src/components/calendars/index.tsx
@@ -53,7 +53,7 @@ import InActive22Icon from "../common/icons/cardNumber/InActive22Icon";
 import InActive23Icon from "../common/icons/cardNumber/InActive23Icon";
 import InActive24Icon from "../common/icons/cardNumber/InActive24Icon";
 import InActive25Icon from "../common/icons/cardNumber/InActive25Icon";
-import { SVGProps } from "react";
+import { SVGProps, useEffect } from "react";
 import type { CalendarItem } from "@/types/calendar";
 
 type IconType = ({ ...props }: SVGProps<SVGSVGElement>) => JSX.Element;
@@ -124,44 +124,20 @@ interface CalendarProps {
 
 const Calendar = ({ isBlurred, userId }: CalendarProps) => {
   const router = useRouter();
-  const { calendarData, error, imageErrors, handleImageError } = useCalendar(
-    userId || 0
+
+  // userId가 유효한 값인지 확인
+  const isValidUserId = !isNaN(Number(userId));
+
+  const { calendarData, imageErrors, handleImageError } = useCalendar(
+    isValidUserId ? Number(userId) : 0
   );
 
-  if (error) {
-    return <div>에러 발생: {error.message}</div>;
-  }
-
-  // const getThumbnailUrl = (dayData: CalendarItem) => {
-  //   // 날짜 비교를 위해 시간을 제거하고 날짜만 비교
-  //   const cardDate = new Date(dayData.calendar_dt);
-  //   cardDate.setHours(0, 0, 0, 0);
-
-  //   const today = new Date();
-  //   today.setHours(0, 0, 0, 0);
-
-  //   // 날짜 비교를 위해 타임스탬프 사용
-  //   const cardTimestamp = cardDate.getTime();
-  //   const todayTimestamp = today.getTime();
-
-  //   // 오늘 이하(이전 날짜 + 오늘)인 경우 YouTube 썸네일
-  //   if (cardTimestamp <= todayTimestamp && dayData.youtube_video_id) {
-  //     return `https://img.youtube.com/vi/${dayData.youtube_video_id}/maxresdefault.jpg`;
-  //   }
-
-  //   // 오늘 초과인 경우 캘린더 썸네일
-  //   if (cardTimestamp > todayTimestamp && dayData.calendar_thumbnail) {
-  //     return dayData.calendar_thumbnail;
-  //   }
-
-  //   // youtube_video_id나 calendar_thumbnail이 없는 경우
-  //   return "/default_thumbnail.png";
-  // };
-
   const handleCalendarClick = (day: number) => {
-    userId
-      ? router.push(`/calendars/card/user/${userId}/${day}`)
-      : router.push(`/calendars/card/${day}`);
+    if (isValidUserId) {
+      router.push(`/calendars/card/user/${userId}/${day}`);
+    } else {
+      router.push(`/calendars/card/${day}`);
+    }
   };
 
   return (

--- a/src/components/calendars/index.tsx
+++ b/src/components/calendars/index.tsx
@@ -54,6 +54,7 @@ import InActive23Icon from "../common/icons/cardNumber/InActive23Icon";
 import InActive24Icon from "../common/icons/cardNumber/InActive24Icon";
 import InActive25Icon from "../common/icons/cardNumber/InActive25Icon";
 import { SVGProps } from "react";
+import type { CalendarItem } from "@/types/calendar";
 
 type IconType = ({ ...props }: SVGProps<SVGSVGElement>) => JSX.Element;
 type IconMapType = { [key: number]: IconType };
@@ -118,49 +119,52 @@ const InactiveIcons: IconMapType = {
 
 interface CalendarProps {
   isBlurred: boolean;
+  userId?: number;
 }
 
-const Calendar = ({ isBlurred }: CalendarProps) => {
+const Calendar = ({ isBlurred, userId }: CalendarProps) => {
   const router = useRouter();
-  const { calendarData, error, imageErrors, handleImageError } = useCalendar();
-
-  const getThumbnailUrl = (dayData: any) => {
-    // 날짜 비교를 위해 시간을 제거하고 날짜만 비교
-    const cardDate = new Date(dayData.calendar_dt);
-    cardDate.setHours(0, 0, 0, 0);
-
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-
-    // 날짜 비교를 위해 타임스탬프 사용
-    const cardTimestamp = cardDate.getTime();
-    const todayTimestamp = today.getTime();
-
-    // 오늘 이하(이전 날짜 + 오늘)인 경우 YouTube 썸네일
-    if (cardTimestamp <= todayTimestamp && dayData.youtube_video_id) {
-      return `https://img.youtube.com/vi/${dayData.youtube_video_id}/maxresdefault.jpg`;
-    }
-
-    // 오늘 초과인 경우 캘린더 썸네일
-    if (cardTimestamp > todayTimestamp && dayData.calendar_thumbnail) {
-      return dayData.calendar_thumbnail;
-    }
-
-    // youtube_video_id나 calendar_thumbnail이 없는 경우
-    return "/default_thumbnail.png";
-  };
-
-  const handleCalendarClick = (day: number) => {
-    router.push(`/calendars/card/${day}`);
-  };
+  const { calendarData, error, imageErrors, handleImageError } = useCalendar(
+    userId || 0
+  );
 
   if (error) {
     return <div>에러 발생: {error.message}</div>;
   }
 
+  // const getThumbnailUrl = (dayData: CalendarItem) => {
+  //   // 날짜 비교를 위해 시간을 제거하고 날짜만 비교
+  //   const cardDate = new Date(dayData.calendar_dt);
+  //   cardDate.setHours(0, 0, 0, 0);
+
+  //   const today = new Date();
+  //   today.setHours(0, 0, 0, 0);
+
+  //   // 날짜 비교를 위해 타임스탬프 사용
+  //   const cardTimestamp = cardDate.getTime();
+  //   const todayTimestamp = today.getTime();
+
+  //   // 오늘 이하(이전 날짜 + 오늘)인 경우 YouTube 썸네일
+  //   if (cardTimestamp <= todayTimestamp && dayData.youtube_video_id) {
+  //     return `https://img.youtube.com/vi/${dayData.youtube_video_id}/maxresdefault.jpg`;
+  //   }
+
+  //   // 오늘 초과인 경우 캘린더 썸네일
+  //   if (cardTimestamp > todayTimestamp && dayData.calendar_thumbnail) {
+  //     return dayData.calendar_thumbnail;
+  //   }
+
+  //   // youtube_video_id나 calendar_thumbnail이 없는 경우
+  //   return "/default_thumbnail.png";
+  // };
+
+  const handleCalendarClick = (day: number) => {
+    router.push(`/calendars/card/${userId}/${day}`);
+  };
+
   return (
     <CalendarList>
-      {calendarData.map((dayData) => {
+      {calendarData.map((dayData: CalendarItem) => {
         const day = formatCalendarDate(dayData.calendar_dt).day;
         const shouldBlur = isBlurred || isDateBlurred(dayData.calendar_dt);
 

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -12,6 +12,7 @@ interface BaseButtonProps {
   variant: ButtonVariant;
   onClick?: () => void;
   disabled?: boolean;
+  isBlocked?: boolean;
 }
 
 interface StandardButtonProps extends BaseButtonProps {
@@ -51,7 +52,10 @@ const Button = (props: ButtonProps) => {
 };
 export default Button;
 
-const StyledButton = styled.button<{ variant: ButtonVariant }>`
+const StyledButton = styled.button<{
+  variant: ButtonVariant;
+  isBlocked?: boolean;
+}>`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -59,6 +63,8 @@ const StyledButton = styled.button<{ variant: ButtonVariant }>`
   cursor: pointer;
   transition: all 0.2s ease-in-out;
   gap: 10px;
+  width: ${({ isBlocked }) => (isBlocked ? "100%" : "fit-content")};
+  white-space: nowrap;
 
   ${({ variant }) => {
     switch (variant) {

--- a/src/hooks/useCalendar.ts
+++ b/src/hooks/useCalendar.ts
@@ -3,42 +3,37 @@ import { getCalendar, getDefaultCalendar } from "@/api/calendar";
 import type { CalendarItem } from "@/types/calendar";
 import { useAuth } from "@/hooks/useAuth";
 
-export const useCalendar = () => {
-  const { user, isLoading: isAuthLoading } = useAuth();
+export const useCalendar = (userId: number) => {
   const [calendarData, setCalendarData] = useState<CalendarItem[]>([]);
   const [error, setError] = useState<Error | null>(null);
   const [imageErrors, setImageErrors] = useState<Set<number>>(new Set());
+  const { user } = useAuth();
 
   useEffect(() => {
-    if (isAuthLoading) return;
-
     const fetchCalendarData = async () => {
       try {
-        let response;
-        if (user?.accessToken) {
-          response = await getCalendar(user.userId);
+        let data;
+
+        if (user) {
+          // 로그인한 사용자는 개인 캘린더 데이터 조회
+          data = await getCalendar(userId);
+          setCalendarData(data.results.data);
         } else {
-          response = await getDefaultCalendar();
+          // 로그인하지 않은 사용자는 기본 캘린더 데이터 조회
+          const defaultData = await getDefaultCalendar();
+          setCalendarData(defaultData.results.data);
         }
-        const filteredData = response.results.data.slice(0, 25);
-        setCalendarData(filteredData);
       } catch (err) {
-        setError(err as Error);
+        setError(err instanceof Error ? err : new Error("An error occurred"));
       }
     };
 
     fetchCalendarData();
-  }, [user, isAuthLoading]);
+  }, [userId, user]);
 
   const handleImageError = (day: number) => {
-    setImageErrors((prev) => new Set(prev).add(day));
+    setImageErrors((prev) => new Set([...prev, day]));
   };
 
-  return {
-    calendarData,
-    error,
-    imageErrors,
-    handleImageError,
-    isLoading: isAuthLoading,
-  };
+  return { calendarData, error, imageErrors, handleImageError };
 };

--- a/src/hooks/useCalendarCard.ts
+++ b/src/hooks/useCalendarCard.ts
@@ -2,7 +2,7 @@ import { getCalendarCard, getDefaultCalendarCard } from "@/api/calendar";
 import { CalendarCardItem } from "@/types/calendar";
 import { useState, useEffect } from "react";
 
-export const useCalendarCard = (userId?: number, day?: number) => {
+export const useCalendarCard = (userId?: number | null, day?: number) => {
   const [cardData, setCardData] = useState<CalendarCardItem | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
@@ -10,7 +10,7 @@ export const useCalendarCard = (userId?: number, day?: number) => {
   useEffect(() => {
     if (day) {
       // userId가 있으면 로그인한 유저용 API를, 없으면 기본 API를 호출
-      const fetchCard = userId 
+      const fetchCard = userId
         ? getCalendarCard(userId, day)
         : getDefaultCalendarCard(day);
 

--- a/src/pages/calendars/[userId].tsx
+++ b/src/pages/calendars/[userId].tsx
@@ -1,0 +1,101 @@
+import styled from "@emotion/styled";
+import { useAuth } from "@/hooks/useAuth";
+import { useShare } from "@/hooks/useShare";
+import ShareModal from "@/components/common/ShareModal";
+import ProfileSection from "@/components/profile/ProfileSection";
+import { Chip } from "@/components/common/Chip";
+import { useState } from "react";
+import { Text } from "@/components/common/Text";
+import { useRouter } from "next/router";
+import Layout from "@/components/Layout/Layout";
+import Calendar from "@/components/calendars";
+
+const UserCalendar = () => {
+  const router = useRouter();
+  const { userId } = router.query;
+  const { user } = useAuth();
+  const [activeYear, setActiveYear] = useState<"2024" | "2025">("2024");
+
+  const getChipVariant = (year: "2024" | "2025") => {
+    if (activeYear === "2025") {
+      return year === "2024" ? "activeNotClicked" : "inactiveClicked";
+    } else {
+      return year === "2024" ? "active" : "inactive";
+    }
+  };
+
+  const {
+    isShareModalOpen,
+    setIsShareModalOpen,
+    shareUrl,
+    handleCopyLink,
+    handleSaveImage,
+    handleShareSNS,
+  } = useShare({
+    username: user?.username,
+    userId: Number(userId), // URL의 userId 사용
+  });
+
+  return (
+    <Layout>
+      <Main>
+        <ProfileSection />
+        <ChipContainer>
+          <Chip
+            variant={getChipVariant("2024")}
+            onClick={() => setActiveYear("2024")}
+          >
+            2024
+          </Chip>
+          <Chip
+            variant={getChipVariant("2025")}
+            onClick={() => setActiveYear("2025")}
+          >
+            2025
+          </Chip>
+        </ChipContainer>
+        {activeYear === "2024" ? (
+          <Calendar isBlurred={false} userId={Number(userId)} />
+        ) : (
+          <MessageContainer>
+            <Text variant="body" color="grey.1">
+              내년에 또 만나요!
+            </Text>
+          </MessageContainer>
+        )}
+        <ShareModal
+          isOpen={isShareModalOpen}
+          onClose={() => setIsShareModalOpen(false)}
+          shareUrl={shareUrl}
+          onCopyLink={handleCopyLink}
+          onSaveImage={handleSaveImage}
+          onShareSNS={handleShareSNS}
+        />
+      </Main>
+    </Layout>
+  );
+};
+
+export default UserCalendar;
+
+const Main = styled.main`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  margin-top: 20px;
+`;
+
+const ChipContainer = styled.div`
+  display: flex;
+  gap: 8px;
+`;
+
+const MessageContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: calc(100vh - 300px);
+  width: 100%;
+`;

--- a/src/pages/calendars/card/[cardId].tsx
+++ b/src/pages/calendars/card/[cardId].tsx
@@ -20,7 +20,7 @@ import EditIcon from "@/components/common/icons/EditIcon";
 import DeleteIcon from "@/components/common/icons/DeleteIcon";
 import { createGuestbook, GuestbookRequest } from "@/api/guestbook";
 
-// TODO : input 컴포넌트 만들어서 사용하기
+// TODO : input 컴포넌트 만들어 사용하기
 
 const CalendarCardPage = () => {
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -196,11 +196,6 @@ const CalendarCardPage = () => {
 
     try {
       const updateData: UpdateCalendarCardItem = {
-        title: editData.title || "",
-        comment: editData.comment || "",
-        comment_detail: editData.comment_detail || "",
-        youtube_video_id: editData.youtube_video_id || "",
-        youtube_thumbnail_link: `https://img.youtube.com/vi/${editData.youtube_video_id}/maxresdefault.jpg`,
         thumbnail_file: null,
       };
 
@@ -228,6 +223,7 @@ const CalendarCardPage = () => {
       writer_name: user?.username || "",
       content: "",
     });
+    const [isInputFocused, setIsInputFocused] = useState(false);
     const handleSubmitGuestbook = async () => {
       if (!cardData || !guestbookInput.content) return;
 
@@ -251,7 +247,8 @@ const CalendarCardPage = () => {
           content: "",
         });
 
-        // 성공 메시지 또는 새로고침 등 추가 처리
+        // TODO : 성공 메시지 또는 새로고침 등 추가 처리
+        router.reload();
         alert("방명록이 등록되었습니다.");
       } catch (error) {
         console.error("방명록 등록 실패:", error);
@@ -272,7 +269,7 @@ const CalendarCardPage = () => {
             </GuestbookItem>
           ))}
         </GuestbookList>
-        <GuestbookInputWrapper>
+        <GuestbookInputWrapper isFocused={isInputFocused}>
           <InputContainer>
             {user ? (
               <AuthorInput value={user.username} disabled />
@@ -291,16 +288,21 @@ const CalendarCardPage = () => {
             <ContentInput
               placeholder="내용을 남겨주세요. (최대 100자)"
               value={guestbookInput.content}
-              onChange={(e) =>
+              onChange={(e) => {
                 setGuestbookInput((prev) => ({
                   ...prev,
                   content: e.target.value,
-                }))
-              }
+                }));
+              }}
+              onFocus={() => setIsInputFocused(true)}
+              onBlur={() => setIsInputFocused(false)}
               maxLength={100}
+              rows={1}
             />
           </InputContainer>
-          <SubmitButton onClick={handleSubmitGuestbook}>등록하기</SubmitButton>
+          <SubmitButton variant="register" onClick={handleSubmitGuestbook}>
+            등록하기
+          </SubmitButton>
         </GuestbookInputWrapper>
       </GuestbookWrapper>
     );
@@ -450,10 +452,12 @@ export default CalendarCardPage;
 const Container = styled.div`
   width: 100%;
   margin: 0 auto;
-  padding: 20px;
+  padding: 20px 0;
   display: flex;
   flex-direction: column;
-  align-item: center;
+  align-items: center;
+  justify-content: center;
+
   gap: 20px;
 `;
 
@@ -516,8 +520,7 @@ const CommentInput = styled.textarea`
   border: none;
   resize: none;
   text-align: center;
-  font-size: 20px;
-  font-weight: 700;
+  font-size: 14px;
   color: ${colors.black};
   &::placeholder {
     color: ${colors.grey[1]};
@@ -595,6 +598,7 @@ const SearchResultTitle = styled.div`
 
 const GuestbookWrapper = styled.div`
   margin-top: 24px;
+  width: 100%;
 `;
 
 const GuestbookTitle = styled.h2`
@@ -604,10 +608,17 @@ const GuestbookTitle = styled.h2`
 `;
 
 const GuestbookList = styled.div`
-  display: flex;
-  flex-direction: column;
+  display: grid;
   gap: 12px;
   margin-bottom: 20px;
+
+  // 모바일 기본값: 1열
+  grid-template-columns: 1fr;
+
+  // 768px 이상일 때 3열로 변경
+  @media (min-width: 768px) {
+    grid-template-columns: repeat(3, 1fr);
+  }
 `;
 
 const GuestbookItem = styled.div`
@@ -615,27 +626,34 @@ const GuestbookItem = styled.div`
   border-radius: 8px;
   padding: 16px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  break-inside: avoid;
 `;
 
 const GuestbookAuthor = styled.div`
   font-weight: 500;
   margin-bottom: 8px;
+  color: ${colors.grey[2]};
 `;
 
 const GuestbookContent = styled.div`
-  color: #333;
+  color: ${colors.black};
   font-size: 14px;
   line-height: 1.5;
+  word-break: break-all;
 `;
 
-const GuestbookInputWrapper = styled.div`
+const GuestbookInputWrapper = styled.div<{ isFocused: boolean }>`
   display: flex;
   gap: 12px;
-  align-items: flex-start;
-  background: white;
-  border-radius: 8px;
+  align-items: center;
+  width: 100%;
+  background: ${colors.white};
+  box-sizing: border-box;
+  border-radius: 12px;
   padding: 16px;
-  border: 1px solid #eee;
+  border: 1px solid
+    ${(props) => (props.isFocused ? colors.red[2] : colors.grey[1])};
+  transition: border-color 0.2s ease;
 `;
 
 const InputContainer = styled.div`
@@ -648,39 +666,37 @@ const InputContainer = styled.div`
 const AuthorInput = styled.input`
   border: none;
   outline: none;
-  font-size: 14px;
+  font-size: 15px;
   padding: 8px 0;
-  border-bottom: 1px solid #eee;
-
+  background: transparent;
   &::placeholder {
-    color: #999;
+    color: ${colors.red[3]};
+  }
+
+  &:disabled {
+    color: ${colors.red[3]};
+    cursor: default;
   }
 `;
 
-const ContentInput = styled.input`
+const ContentInput = styled.textarea`
   border: none;
   outline: none;
   font-size: 14px;
   padding: 8px 0;
+  resize: none;
+  height: auto;
+  overflow-y: hidden;
+  line-height: 1.5;
 
   &::placeholder {
-    color: #999;
+    color: ${colors.grey[1]};
   }
 `;
 
-const SubmitButton = styled.button`
-  background: #f4a7aa;
-  color: white;
-  border: none;
-  border-radius: 8px;
-  padding: 8px 16px;
-  cursor: pointer;
-  font-size: 14px;
-  white-space: nowrap;
-
-  &:hover {
-    background: #f39599;
-  }
+const SubmitButton = styled(Button)`
+  flex-shrink: 0;
+  height: fit-content;
 `;
 
 const PlayButton = styled.button`

--- a/src/pages/calendars/card/user/[userId]/[day].tsx
+++ b/src/pages/calendars/card/user/[userId]/[day].tsx
@@ -1,0 +1,747 @@
+import { useRef } from "react";
+import { useCalendarCard } from "@/hooks/useCalendarCard";
+import { updateCalendarCard } from "@/api/calendar";
+import { useRouter } from "next/router";
+import Layout from "@/components/Layout/Layout";
+import styled from "@emotion/styled";
+import { useState, useEffect } from "react";
+import { UpdateCalendarCardItem } from "@/types/calendar";
+import { useAuth } from "@/hooks/useAuth";
+import { getYoutubeKeywordSearch } from "@/api/search";
+import Button from "@/components/common/Button";
+import { YoutubeVideo } from "@/types/serach";
+import { colors } from "@/styles/colors";
+import { useShare } from "@/hooks/useShare";
+import React from "react";
+import Active1Icon from "@/components/common/icons/cardNumber/Active1Icon";
+import { Text } from "@/components/common/Text";
+import SongChangeIcon from "@/components/common/icons/SongChangeIcon";
+import EditIcon from "@/components/common/icons/EditIcon";
+import DeleteIcon from "@/components/common/icons/DeleteIcon";
+import { createGuestbook, GuestbookRequest } from "@/api/guestbook";
+
+// TODO : input 컴포넌트 만들어 사용하기
+
+const CalendarCardPage = () => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const commentRef = useRef<HTMLTextAreaElement>(null);
+  const commentDetailRef = useRef<HTMLTextAreaElement>(null);
+  const router = useRouter();
+  const { day: cardId, userId } = router.query;
+  const { user } = useAuth();
+  const { cardData, isLoading, error } = useCalendarCard(
+    Number(userId),
+    Number(cardId)
+  );
+
+  const {
+    isShareModalOpen,
+    setIsShareModalOpen,
+    shareUrl,
+    handleCopyLink,
+    handleSaveImage,
+    handleShareSNS,
+  } = useShare({
+    username: user?.username,
+    userId: user?.userId,
+    baseUrl: `https://dev.myadvent-calendar.com/calendars/card/${cardId}`,
+  });
+
+  const [editData, setEditData] = useState<UpdateCalendarCardItem>();
+  const [searchKeyword, setSearchKeyword] = useState("");
+  const [searchResults, setSearchResults] = useState<YoutubeVideo[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [isVideoPlaying, setIsVideoPlaying] = useState(false);
+
+  // thumbnail_file 이 있을 때 먼저 thumbnail_file 을 사용하고 없으면 calendar_thumbnail 을 사용
+  const thumbnailUrl = cardData?.thumbnail_file
+    ? cardData.thumbnail_file
+    : cardData?.calendar_thumbnail
+    ? cardData.calendar_thumbnail
+    : undefined;
+  useEffect(() => {
+    if (cardId && isNaN(Number(cardId))) {
+      router.push("/404");
+    }
+  }, [cardId]);
+
+  useEffect(() => {
+    if (cardData) {
+      setEditData({
+        youtube_thumbnail_link: cardData.calendar_thumbnail || "",
+        youtube_video_id: cardData.youtube_video_id || "",
+        title: cardData.title || "",
+        comment: cardData.comment || "",
+        comment_detail: cardData.comment_detail || "",
+        thumbnail_file: null,
+      });
+    }
+  }, [cardData]);
+
+  const handleSearch = async () => {
+    if (!searchKeyword.trim()) return;
+
+    try {
+      setIsSearching(true);
+      const response = await getYoutubeKeywordSearch(searchKeyword);
+
+      setSearchResults(response.results.data);
+    } catch (error) {
+      console.error("검색 실패:", error);
+      alert("검색 중 오류가 발생했습니다.");
+    } finally {
+      setIsSearching(false);
+    }
+  };
+
+  const handleSelectVideo = async (videoId: string, title: string) => {
+    if (!user?.userId || !cardData) return;
+
+    try {
+      const updateData = {
+        ...editData,
+        title: title,
+        youtube_video_id: videoId,
+        youtube_thumbnail_link: `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`,
+      };
+
+      await updateCalendarCard(
+        user.accessToken || "",
+        user.userId,
+        Number(cardId),
+        updateData
+      );
+
+      setEditData(updateData);
+      setSearchResults([]);
+      setSearchKeyword("");
+
+      // 업데이트 후 페이지 새로고침
+      router.reload();
+    } catch (error) {
+      console.error("업데이트 실패:", error);
+      alert("저장 중 오류가 발생했습니다.");
+    }
+  };
+
+  const handleCommentChange = (
+    e: React.ChangeEvent<HTMLTextAreaElement>,
+    field: "comment" | "comment_detail"
+  ) => {
+    const newValue = e.target.value;
+    setEditData((prev) => ({ ...prev, [field]: newValue }));
+  };
+
+  const handleCommentKeyDown = async (
+    e: React.KeyboardEvent<HTMLTextAreaElement>,
+    field: "comment" | "comment_detail"
+  ) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      const newValue = (e.target as HTMLTextAreaElement).value;
+
+      if (user?.userId && cardData) {
+        try {
+          await updateCalendarCard(
+            user.accessToken || "",
+            user.userId,
+            Number(cardId),
+            { ...editData, [field]: newValue }
+          );
+          // ref를 통한 포커스 아웃
+          commentRef.current?.blur();
+        } catch (error) {
+          console.error("댓글 업데이트 실패:", error);
+        }
+      }
+    }
+  };
+
+  const handleCoverEdit = async (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const file = event.target.files?.[0];
+    if (!file || !user?.userId || !cardData || !editData) return;
+
+    try {
+      console.log("Current editData:", editData);
+
+      const updateData: UpdateCalendarCardItem = {
+        title: editData.title || "",
+        comment: editData.comment || "",
+        comment_detail: editData.comment_detail || "",
+        youtube_video_id: editData.youtube_video_id || "",
+        youtube_thumbnail_link: editData.youtube_thumbnail_link || "",
+        thumbnail_file: file,
+      };
+
+      console.log("Sending updateData:", updateData);
+
+      await updateCalendarCard(
+        user.accessToken || "",
+        user.userId,
+        Number(cardId),
+        updateData
+      );
+
+      router.reload();
+    } catch (error) {
+      console.error("커버 업데이트 실패:", error);
+      alert("커버 이미지 업데이트 중 오류가 발생했습니다.");
+    }
+  };
+
+  const handleCoverDelete = async () => {
+    if (!user?.userId || !cardData || !editData) return;
+
+    try {
+      const updateData: UpdateCalendarCardItem = {
+        thumbnail_file: null,
+      };
+
+      await updateCalendarCard(
+        user.accessToken || "",
+        user.userId,
+        Number(cardId),
+        updateData
+      );
+
+      router.reload();
+    } catch (error) {
+      console.error("커버 삭제 실패:", error);
+      alert("커버 이미지 삭제 중 오류가 발생했습니다.");
+    }
+  };
+
+  interface GuestbookInput {
+    writer_name: string;
+    content: string;
+  }
+
+  const GuestbookSection = () => {
+    const [guestbookInput, setGuestbookInput] = useState<GuestbookInput>({
+      writer_name: user?.username || "",
+      content: "",
+    });
+    const [isInputFocused, setIsInputFocused] = useState(false);
+    const handleSubmitGuestbook = async () => {
+      if (!cardData || !guestbookInput.content) return;
+
+      try {
+        const requestData: GuestbookRequest = {
+          content: guestbookInput.content,
+          // 로그인하지 않은 경우에만 writer_name 전송
+          ...(user ? {} : { writer_name: guestbookInput.writer_name }),
+        };
+
+        await createGuestbook(
+          Number(userId),
+          Number(cardId),
+          requestData,
+          user?.accessToken
+        );
+
+        // 입력 필드 초기화
+        setGuestbookInput({
+          writer_name: user?.username || "",
+          content: "",
+        });
+
+        // TODO : 성공 메시지 또는 새로고침 등 추가 처리
+        router.reload();
+        alert("방명록이 등록되었습니다.");
+      } catch (error) {
+        console.error("방명록 등록 실패:", error);
+        alert("방명록 등록에 실패했습니다.");
+      }
+    };
+
+    return (
+      <GuestbookWrapper>
+        <GuestbookTitle>방명록 {cardData?.guestbooks.length}개</GuestbookTitle>
+        <GuestbookList>
+          {cardData?.guestbooks.map((guestbook, index) => (
+            <GuestbookItem key={index}>
+              <GuestbookAuthor>
+                {guestbook.writer_name || "익명"}
+              </GuestbookAuthor>
+              <GuestbookContent>{guestbook.content}</GuestbookContent>
+            </GuestbookItem>
+          ))}
+        </GuestbookList>
+        <GuestbookInputWrapper isFocused={isInputFocused}>
+          <InputContainer>
+            {user ? (
+              <AuthorInput value={user.username} disabled />
+            ) : (
+              <AuthorInput
+                placeholder="작성자명"
+                value={guestbookInput.writer_name}
+                onChange={(e) =>
+                  setGuestbookInput((prev) => ({
+                    ...prev,
+                    writer_name: e.target.value,
+                  }))
+                }
+              />
+            )}
+            <ContentInput
+              placeholder="내용을 남겨주세요. (최대 100자)"
+              value={guestbookInput.content}
+              onChange={(e) => {
+                setGuestbookInput((prev) => ({
+                  ...prev,
+                  content: e.target.value,
+                }));
+              }}
+              onFocus={() => setIsInputFocused(true)}
+              onBlur={() => setIsInputFocused(false)}
+              maxLength={100}
+              rows={1}
+            />
+          </InputContainer>
+          <SubmitButton variant="register" onClick={handleSubmitGuestbook}>
+            등록하기
+          </SubmitButton>
+        </GuestbookInputWrapper>
+      </GuestbookWrapper>
+    );
+  };
+
+  if (isLoading) return <div>로딩 중...</div>;
+  if (error) return <div>에러 발생: {error.message}</div>;
+  if (!cardData) return <div>데이터를 찾을 수 없습니다.</div>;
+
+  return (
+    <Layout>
+      <Container>
+        <CardWrapper>
+          <ThumbnailContainer>
+            {!isVideoPlaying ? (
+              <>
+                <ThumbnailImage src={thumbnailUrl} alt="YouTube Thumbnail" />
+                <ButtonOverlay>
+                  <PlayButton onClick={() => setIsVideoPlaying(true)}>
+                    ▶
+                  </PlayButton>
+                  {user && (
+                    <CoverButtonGroup>
+                      <input
+                        type="file"
+                        ref={fileInputRef}
+                        onChange={handleCoverEdit}
+                        accept="image/*"
+                        style={{ display: "none" }}
+                      />
+                      <CoverButton
+                        onClick={() => fileInputRef.current?.click()}
+                      >
+                        <EditIcon width={14} height={14} color="#6F6E6E" />
+                        커버 수정
+                      </CoverButton>
+                      {cardData.thumbnail_file && (
+                        <CoverButton onClick={handleCoverDelete}>
+                          <DeleteIcon color="#6F6E6E" />
+                          커버 삭제
+                        </CoverButton>
+                      )}
+                    </CoverButtonGroup>
+                  )}
+                </ButtonOverlay>
+              </>
+            ) : (
+              <YoutubeEmbed>
+                <iframe
+                  width="100%"
+                  height="100%"
+                  src={`https://www.youtube.com/embed/${cardData.youtube_video_id}?enablejsapi=1&autoplay=1&mute=1&rel=0`}
+                  title="YouTube video player"
+                  frameBorder="0"
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                  allowFullScreen
+                />
+              </YoutubeEmbed>
+            )}
+          </ThumbnailContainer>
+
+          <ContentInfo>
+            <Active1Icon variant="detail" />
+            <Text variant="heading">{cardData.title}</Text>
+          </ContentInfo>
+
+          {user && (
+            <HeaderSection>
+              <SearchContainer>
+                <SearchInputWrapper>
+                  <IconWrapper>
+                    <SongChangeIcon />
+                  </IconWrapper>
+                  <SearchInput
+                    value={searchKeyword}
+                    onChange={(e) => setSearchKeyword(e.target.value)}
+                    onKeyPress={(e) => e.key === "Enter" && handleSearch()}
+                    placeholder="노래 검색..."
+                    disabled={isSearching}
+                  />
+                </SearchInputWrapper>
+              </SearchContainer>
+            </HeaderSection>
+          )}
+
+          {isSearching ? (
+            <SearchResults>
+              <SearchResultItem>
+                <SearchResultTitle>검색 중...</SearchResultTitle>
+              </SearchResultItem>
+            </SearchResults>
+          ) : (
+            searchResults.length > 0 && (
+              <SearchResults>
+                {searchResults.map((result) => {
+                  return (
+                    <SearchResultItem key={result.youtube_video_id}>
+                      <div>
+                        <SearchResultTitle>{result.title}</SearchResultTitle>
+                      </div>
+                      <Button
+                        onClick={() =>
+                          handleSelectVideo(
+                            result.youtube_video_id,
+                            result.title
+                          )
+                        }
+                        variant="select"
+                      >
+                        선택
+                      </Button>
+                    </SearchResultItem>
+                  );
+                })}
+              </SearchResults>
+            )
+          )}
+
+          <CommentWrapper>
+            <CommentContainer>
+              <CommentInput
+                ref={commentRef}
+                placeholder="오늘의 코멘트"
+                value={editData?.comment || ""}
+                onChange={(e) => handleCommentChange(e, "comment")}
+                onKeyDown={(e) => handleCommentKeyDown(e, "comment")}
+              />
+              <CommentDetailInput
+                ref={commentDetailRef}
+                placeholder="내용을 자유롭게 남겨주세요"
+                value={editData?.comment_detail}
+                onChange={(e) => handleCommentChange(e, "comment_detail")}
+                onKeyPress={(e) => handleCommentKeyDown(e, "comment_detail")}
+              />
+            </CommentContainer>
+          </CommentWrapper>
+        </CardWrapper>
+        <GuestbookSection />
+        <Button variant="export">내보내기</Button>
+      </Container>
+    </Layout>
+  );
+};
+
+export default CalendarCardPage;
+
+const Container = styled.div`
+  width: 100%;
+  margin: 0 auto;
+  padding: 20px 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  gap: 20px;
+`;
+
+const ThumbnailContainer = styled.div`
+  position: relative;
+  width: 100%;
+  padding-top: 56.25%;
+  background-color: #000;
+`;
+
+const CardWrapper = styled.div`
+  width: 100%;
+  background: white;
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+`;
+
+const ThumbnailImage = styled.img`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  background-color: #000;
+`;
+
+const YoutubeEmbed = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+`;
+
+const ContentInfo = styled.div`
+  padding: 20px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+const CommentWrapper = styled.div`
+  padding: 20px;
+  border-top: 1px solid #eee;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;
+
+const CommentContainer = styled.div`
+  border: 1px solid #eee;
+  border-radius: 8px;
+  overflow: hidden;
+`;
+
+const CommentInput = styled.textarea`
+  width: 100%;
+  border: none;
+  resize: none;
+  text-align: center;
+  font-size: 14px;
+  color: ${colors.black};
+  &::placeholder {
+    color: ${colors.grey[1]};
+  }
+`;
+
+const CommentDetailInput = styled(CommentInput)`
+  color: ${colors.black};
+  font-size: 16px;
+  font-weight: 500;
+  &::placeholder {
+    color: ${colors.grey[1]};
+  }
+`;
+
+const HeaderSection = styled.div``;
+
+const SearchContainer = styled.div`
+  display: flex;
+  gap: 1rem;
+  width: 100%;
+`;
+
+const SearchInputWrapper = styled.div`
+  position: relative;
+  flex: 1;
+  display: flex;
+  align-items: center;
+`;
+
+const IconWrapper = styled.div`
+  position: absolute;
+  left: 12px;
+  display: flex;
+  align-items: center;
+`;
+
+const SearchInput = styled.input`
+  width: 100%;
+  padding: 0.75rem;
+  padding-left: 40px;
+  border: 1px solid ${colors.grey[2]};
+  border-radius: 8px;
+  font-size: 1rem;
+
+  &::placeholder {
+    color: ${colors.grey[2]};
+  }
+`;
+
+const SearchResults = styled.div`
+  margin-bottom: 1rem;
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+`;
+
+const SearchResultItem = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  border-bottom: 1px solid ${colors.grey[1]};
+
+  &:last-child {
+    border-bottom: none;
+  }
+`;
+
+const SearchResultTitle = styled.div`
+  font-size: 1rem;
+  margin-right: 1rem;
+`;
+
+const GuestbookWrapper = styled.div`
+  margin-top: 24px;
+  width: 100%;
+`;
+
+const GuestbookTitle = styled.h2`
+  font-size: 16px;
+  color: #666;
+  margin-bottom: 16px;
+`;
+
+const GuestbookList = styled.div`
+  display: grid;
+  gap: 12px;
+  margin-bottom: 20px;
+
+  // 모바일 기본값: 1열
+  grid-template-columns: 1fr;
+
+  // 768px 이상일 때 3열로 변경
+  @media (min-width: 768px) {
+    grid-template-columns: repeat(3, 1fr);
+  }
+`;
+
+const GuestbookItem = styled.div`
+  background: white;
+  border-radius: 8px;
+  padding: 16px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  break-inside: avoid;
+`;
+
+const GuestbookAuthor = styled.div`
+  font-weight: 500;
+  margin-bottom: 8px;
+  color: ${colors.grey[2]};
+`;
+
+const GuestbookContent = styled.div`
+  color: ${colors.black};
+  font-size: 14px;
+  line-height: 1.5;
+  word-break: break-all;
+`;
+
+const GuestbookInputWrapper = styled.div<{ isFocused: boolean }>`
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  width: 100%;
+  background: ${colors.white};
+  box-sizing: border-box;
+  border-radius: 12px;
+  padding: 16px;
+  border: 1px solid
+    ${(props) => (props.isFocused ? colors.red[2] : colors.grey[1])};
+  transition: border-color 0.2s ease;
+`;
+
+const InputContainer = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+const AuthorInput = styled.input`
+  border: none;
+  outline: none;
+  font-size: 15px;
+  padding: 8px 0;
+  background: transparent;
+  &::placeholder {
+    color: ${colors.red[3]};
+  }
+
+  &:disabled {
+    color: ${colors.red[3]};
+    cursor: default;
+  }
+`;
+
+const ContentInput = styled.textarea`
+  border: none;
+  outline: none;
+  font-size: 14px;
+  padding: 8px 0;
+  resize: none;
+  height: auto;
+  overflow-y: hidden;
+  line-height: 1.5;
+
+  &::placeholder {
+    color: ${colors.grey[1]};
+  }
+`;
+
+const SubmitButton = styled(Button)`
+  flex-shrink: 0;
+  height: fit-content;
+`;
+
+const PlayButton = styled.button`
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.5);
+  border: none;
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: white;
+  font-size: 24px;
+`;
+
+const ButtonOverlay = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center; // 중앙 정렬로 변경
+  align-items: center;
+  background: rgba(0, 0, 0, 0.3);
+`;
+
+const CoverButtonGroup = styled.div`
+  position: absolute; // 절대 위치로 변경
+  bottom: 16px; // 하단에서의 간격
+  right: 16px; // 우측에서의 간격
+  display: flex;
+  gap: 8px; // 버튼 사이 간격
+`;
+
+const CoverButton = styled.button`
+  padding: 8px 16px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.6);
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+  display: flex; // flex 추가
+  align-items: center; // 수직 중앙 정렬
+  justify-content: center; // 수평 중앙 정렬
+  gap: 4px; // 아이콘과 텍스트 사이 간격
+`;

--- a/src/pages/calendars/index.tsx
+++ b/src/pages/calendars/index.tsx
@@ -1,0 +1,91 @@
+import styled from "@emotion/styled";
+import { useShare } from "@/hooks/useShare";
+import ShareModal from "@/components/common/ShareModal";
+import { Chip } from "@/components/common/Chip";
+import { useState } from "react";
+import { Text } from "@/components/common/Text";
+import Layout from "@/components/Layout/Layout";
+import Calendar from "@/components/calendars";
+
+const DefaultCalendar = () => {
+  const [activeYear, setActiveYear] = useState<"2024" | "2025">("2024");
+
+  const getChipVariant = (year: "2024" | "2025") => {
+    if (activeYear === "2025") {
+      return year === "2024" ? "activeNotClicked" : "inactiveClicked";
+    } else {
+      return year === "2024" ? "active" : "inactive";
+    }
+  };
+
+  //   const {
+  //     isShareModalOpen,
+  //     setIsShareModalOpen,
+  //     shareUrl,
+  //     handleCopyLink,
+  //     handleSaveImage,
+  //     handleShareSNS,
+  //   } = useShare({});
+
+  return (
+    <Layout>
+      <Main>
+        <ChipContainer>
+          <Chip
+            variant={getChipVariant("2024")}
+            onClick={() => setActiveYear("2024")}
+          >
+            2024
+          </Chip>
+          <Chip
+            variant={getChipVariant("2025")}
+            onClick={() => setActiveYear("2025")}
+          >
+            2025
+          </Chip>
+        </ChipContainer>
+        {activeYear === "2024" ? (
+          <Calendar isBlurred={false} />
+        ) : (
+          <MessageContainer>
+            <Text variant="body" color="grey.1">
+              내년에 또 만나요!
+            </Text>
+          </MessageContainer>
+        )}
+        {/* <ShareModal
+          isOpen={isShareModalOpen}
+          onClose={() => setIsShareModalOpen(false)}
+          shareUrl={shareUrl}
+          onCopyLink={handleCopyLink}
+          onSaveImage={handleSaveImage}
+          onShareSNS={handleShareSNS}
+        /> */}
+      </Main>
+    </Layout>
+  );
+};
+
+export default DefaultCalendar;
+
+const Main = styled.main`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  margin-top: 20px;
+`;
+
+const ChipContainer = styled.div`
+  display: flex;
+  gap: 8px;
+`;
+
+const MessageContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: calc(100vh - 300px);
+  width: 100%;
+`;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,98 +1,21 @@
-import styled from "@emotion/styled";
-import Layout from "../components/Layout/Layout";
-import Calendar from "../components/calendars";
+import { useEffect } from "react";
+import { useRouter } from "next/router";
 import { useAuth } from "@/hooks/useAuth";
-import { useShare } from "@/hooks/useShare";
-import ShareModal from "@/components/common/ShareModal";
-import ProfileSection from "@/components/profile/ProfileSection";
-import { Chip } from "@/components/common/Chip";
-import { useState } from "react";
-import { Text } from "@/components/common/Text";
+import { API_ENDPOINTS } from "@/constants/api";
+
 const Home = () => {
+  const router = useRouter();
   const { user } = useAuth();
-  const [activeYear, setActiveYear] = useState<"2024" | "2025">("2024");
 
-  const getChipVariant = (year: "2024" | "2025") => {
-    if (activeYear === "2025") {
-      return year === "2024" ? "activeNotClicked" : "inactiveClicked";
+  useEffect(() => {
+    if (user) {
+      router.push(`${API_ENDPOINTS.CALENDAR.LIST}/${user.userId}`);
     } else {
-      return year === "2024" ? "active" : "inactive";
+      router.push(`${API_ENDPOINTS.CALENDAR.LIST}`);
     }
-  };
+  }, [user, router]);
 
-  const {
-    isShareModalOpen,
-    setIsShareModalOpen,
-    shareUrl,
-    handleCopyLink,
-    handleSaveImage,
-    handleShareSNS,
-  } = useShare({
-    username: user?.username,
-    userId: user?.userId,
-  });
-
-  return (
-    <Layout>
-      <Main>
-        <ProfileSection />
-        <ChipContainer>
-          <Chip
-            variant={getChipVariant("2024")}
-            onClick={() => setActiveYear("2024")}
-          >
-            2024
-          </Chip>
-          <Chip
-            variant={getChipVariant("2025")}
-            onClick={() => setActiveYear("2025")}
-          >
-            2025
-          </Chip>
-        </ChipContainer>
-        {activeYear === "2024" ? (
-          <Calendar isBlurred={false} />
-        ) : (
-          <MessageContainer>
-            <Text variant="body" color="grey.1">
-              내년에 또 만나요!
-            </Text>
-          </MessageContainer>
-        )}
-        <ShareModal
-          isOpen={isShareModalOpen}
-          onClose={() => setIsShareModalOpen(false)}
-          shareUrl={shareUrl}
-          onCopyLink={handleCopyLink}
-          onSaveImage={handleSaveImage}
-          onShareSNS={handleShareSNS}
-        />
-      </Main>
-    </Layout>
-  );
+  return null;
 };
 
 export default Home;
-
-const Main = styled.main`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 20px;
-  margin-top: 20px;
-`;
-
-const ChipContainer = styled.div`
-  display: flex;
-  gap: 8px;
-`;
-
-const MessageContainer = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  // TODO: 수정해야함
-  height: calc(100vh - 300px);
-  width: 100%;
-`;


### PR DESCRIPTION
# 💡 주요 변경 사항
- 캘린더 라우팅 구조 개선
- userId 처리 로직 개선
- 다른 유저의 캘린더 조회 기능 구현
- 재사용 함수인 request 를 formData 용으로 분리하여 작업
- 방명록 UI 수정

# 🔍 상세 변경 내용

### 신규 기능 추가
- 라우팅 구조 개선
  - 로그인 유저용 경로: `/calendars/card/user/{userId}/{day}`
  - 비로그인 유저용 경로: `/calendars/card/{day}`
- 방명록 API 관련 로그인한 유저가 accessToken을 넘겨주고있지 않는 문제 해결
- userId 유효성 검사 로직 추가
  - NaN 체크를 통한 유효한 userId 확인
  - 유효하지 않은 경우 undefined 처리

### 버그 수정
- 페이지 초기 로딩 시 userId가 NaN으로 표시되는 문제 해결
    - hydration 과정에서 발생하는 불필요한 API 호출 방지해야함!! 

# 🔗 관련 작업
- 파일 구조 변경
  ```
  pages/
    └── calendars/
        └── card/
            ├── user/
            │   └── [userId]/
            │       └── [day].tsx    // 로그인 유저용
            └── [day].tsx            // 비로그인 유저용
  ```
- Calendar 컴포넌트 내 라우팅 로직 개선
- useCalendar 훅 호출 시 유효성 검사 추가

# ⏭️ 다음 작업에서 진행 할 작업들
- [ ] API 에러 처리 개선
- [ ] hydration 에러 수정

# 🔍 구현한 흐름
1. 사용자 상태 확인 (로그인/비로그인)
2. userId 유효성 검사
3. 적절한 라우팅 경로로 이동
4. 해당하는 캘린더 데이터 로드